### PR TITLE
Update common.py

### DIFF
--- a/common.py
+++ b/common.py
@@ -263,7 +263,7 @@ def get_buff_hash_proof(access_token: string, realpath: string) -> dict:
         sha1_file = realpath + ".sha1"
         if os.path.exists(sha1_file):
             with open(sha1_file, 'r') as text:
-                data = text.read().split("|")
+                data = text.read().strip().split("|")
                 if len(data) >= 2 and int(data[0]) == filesize:
                     hash = data[1]
                     print_info("从文件读取sha1: " + sha1_file + ", 内容: " + str(data))

--- a/common.py
+++ b/common.py
@@ -258,7 +258,21 @@ def get_buff_hash_proof(access_token: string, realpath: string) -> dict:
     with open(realpath, 'rb') as buff:
         filesize = os.path.getsize(realpath)
         if filesize == 0: return {'sha1': 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709', 'proof_code': ''};
-        hash = get_hash(realpath).upper()
+
+        hash = ""
+        sha1_file = realpath + ".sha1"
+        if os.path.exists(sha1_file):
+            with open(sha1_file, 'r') as text:
+                data = text.read().split("|")
+                if len(data) >= 2 and int(data[0]) == filesize:
+                    hash = data[1]
+                    print_info("从文件读取sha1: " + sha1_file + ", 内容: " + str(data))
+        if hash == "":
+            hash = get_hash(realpath).upper()
+            f = open(sha1_file, 'w+')
+            f.write(str(filesize) + "|" + hash)
+            f.close();
+
         m = html.unescape(parse.quote(access_token))
 
         buffa = m

--- a/common.py
+++ b/common.py
@@ -260,18 +260,18 @@ def get_buff_hash_proof(access_token: string, realpath: string) -> dict:
         if filesize == 0: return {'sha1': 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709', 'proof_code': ''};
 
         hash = ""
-        sha1_file = realpath + ".sha1"
-        if os.path.exists(sha1_file):
-            with open(sha1_file, 'r') as text:
-                data = text.read().strip().split("|")
+        sha1path = realpath + ".sha1"
+        if os.path.exists(sha1path):
+            with open(sha1path, 'r') as f:
+                text = f.read().strip()
+                data = text.split("|")
                 if len(data) >= 2 and int(data[0]) == filesize:
                     hash = data[1]
-                    print_info("从文件读取sha1: " + sha1_file + ", 内容: " + str(data))
+                    print_info("从文件读取sha1: " + sha1path + ", 内容: " + text)
         if hash == "":
             hash = get_hash(realpath).upper()
-            f = open(sha1_file, 'w+')
-            f.write(str(filesize) + "|" + hash)
-            f.close();
+            with open(sha1path, 'w+') as f:
+                f.write(str(filesize) + "|" + hash)
 
         m = html.unescape(parse.quote(access_token))
 


### PR DESCRIPTION
优化大文件，添加从文件读取sha1。

超过1T的文件，由于上传太长，上传过程中会出现上传地址失效的情况。这时如果重新上传，会再次计算sha1，然而每次计算sha1都会花费好几个小时，因此添加了这个功能。
实现比较简单，也没有考虑太多异常情况，希望作者在此基础上优化一下。这个功能对于大文件来说至关重要！感谢作者！
PS: 尝试了rclone/WebDAV和其他的API后，发现这个工具是最棒的，真心感谢！