### PR TITLE
sort file and directories by name

### DIFF
--- a/common.py
+++ b/common.py
@@ -128,7 +128,7 @@ def get_hash(filepath, block_size=2 * 1024 * 1024):
 
 def get_all_file(path):
     result = []
-    get_dir = os.listdir(path)
+    get_dir = sorted(os.listdir(path))
     for i in get_dir:
         sub_dir = os.path.join(path, i)
         if os.path.isdir(sub_dir):


### PR DESCRIPTION
默认情况下os.listdir返回的文件排序是随机的，导致上传时文件顺序乱序。
添加sorted()方法，按文件名排序，符合直觉和使用习惯。